### PR TITLE
Add OutputProject option to PubSubCDC etc.

### DIFF
--- a/v2/common/src/main/java/com/google/cloud/teleport/v2/transforms/BigQueryDynamicConverters.java
+++ b/v2/common/src/main/java/com/google/cloud/teleport/v2/transforms/BigQueryDynamicConverters.java
@@ -133,7 +133,7 @@ public class BigQueryDynamicConverters {
     @Override
     public TableDestination getTable(KV<TableId, TableRow> destination) {
       TableId tableId = destination.getKey();
-      String tableName = String.format("%s.%s", tableId.getDataset(), tableId.getTable());
+      String tableName = String.format("%s:%s.%s", tableId.getProject(), tableId.getDataset(), tableId.getTable());
       TableDestination dest =
           new TableDestination(tableName, "Name of table pulled from datafields");
 

--- a/v2/pubsub-cdc-to-bigquery/README.md
+++ b/v2/pubsub-cdc-to-bigquery/README.md
@@ -73,6 +73,13 @@ echo '{
             "isOptional":true
         },
         {
+            "name":"useDeadLetterTable",
+            "label":"This determines if failed records inserts to dead-letter table or GCS",
+            "helpText":"This determines if failed records inserts to dead-letter table or GCS",
+            "paramType":"TEXT",
+            "isOptional":true
+        },
+        {
             "name":"outputDatasetTemplate",
             "label":"The BigQuery Dataset Name or column template",
             "helpText":"The BigQuery Dataset Name or column template",

--- a/v2/pubsub-cdc-to-bigquery/README.md
+++ b/v2/pubsub-cdc-to-bigquery/README.md
@@ -80,6 +80,13 @@ echo '{
             "isOptional":true
         },
         {
+            "name":"outputProject",
+            "label":"The GCP project id for BigQuery Dataset",
+            "helpText":"The GCP project id for BigQuery Dataset",
+            "paramType":"TEXT",
+            "isOptional":true
+        },
+        {
             "name":"outputDatasetTemplate",
             "label":"The BigQuery Dataset Name or column template",
             "helpText":"The BigQuery Dataset Name or column template",

--- a/v2/pubsub-cdc-to-bigquery/src/main/java/com/google/cloud/teleport/v2/templates/PubSubCdcToBigQuery.java
+++ b/v2/pubsub-cdc-to-bigquery/src/main/java/com/google/cloud/teleport/v2/templates/PubSubCdcToBigQuery.java
@@ -377,7 +377,7 @@ public class PubSubCdcToBigQuery {
                 .withWriteDisposition(WriteDisposition.WRITE_APPEND)
                 .withExtendedErrorInfo()
                 .withMethod(BigQueryIO.Write.Method.STREAMING_INSERTS)
-                .withFailedInsertRetryPolicy(InsertRetryPolicy.alwaysRetry()));
+                .withFailedInsertRetryPolicy(InsertRetryPolicy.retryTransientErrors()));
 
     /*
      * Step 3 Contd.

--- a/v2/pubsub-cdc-to-bigquery/src/main/java/com/google/cloud/teleport/v2/templates/PubSubCdcToBigQuery.java
+++ b/v2/pubsub-cdc-to-bigquery/src/main/java/com/google/cloud/teleport/v2/templates/PubSubCdcToBigQuery.java
@@ -166,6 +166,12 @@ public class PubSubCdcToBigQuery {
 
     void setSchemaFilePath(String value);
 
+    @Description("The GCP project id for BigQuery Dataset")
+    @Default.String("")
+    String getOutputProject();
+
+    void setOutputProject(String value);
+
     @Description("The BigQuery Dataset Template")
     @Default.String("{_metadata_dataset}")
     String getOutputDatasetTemplate();
@@ -267,7 +273,7 @@ public class PubSubCdcToBigQuery {
 
     BigQueryTableConfigManager bqConfigManager =
         new BigQueryTableConfigManager(
-            (String) options.as(GcpOptions.class).getProject(),
+            (String) (options.getOutputProject().isEmpty() ? options.as(GcpOptions.class).getProject() : options.getOutputProject()),
             (String) options.getOutputDatasetTemplate(),
             (String) options.getOutputTableNameTemplate(),
             (String) options.getOutputTableSpec());


### PR DESCRIPTION
As of 2023-01-12, 
this branch is branched from https://github.com/GoogleCloudPlatform/DataflowTemplates/tree/2022-10-18-00_RC00 and has following additional features:

- [Fix TableDestination implicitly dependence on the default gcp project](https://github.com/1st-penguin/DataflowTemplates/commit/b425a2c17398dae9a3e9fc9263a4fe8ec50bab95)
- [Add OutputProject option to PubSubCDC](https://github.com/1st-penguin/DataflowTemplates/commit/98b465ce3a2603f8363dc3f4467104f8fd31fe16)
- [Modify InsertRetryPolicy only transient errors cause](https://github.com/1st-penguin/DataflowTemplates/commit/4f2dbff1782b027a5fd0c7d21b31cd97afd83432)
- [Add useDeadLetterTable option](https://github.com/1st-penguin/DataflowTemplates/commit/451c270345942d8d00841b0508949a291fbabd41)